### PR TITLE
Privacy Protection Updates

### DIFF
--- a/domLink.py
+++ b/domLink.py
@@ -183,13 +183,13 @@ def query_yes_no(question, default='yes'):
 
 
 def banner():
-    print ("")
-    print ("DomLink Domain Discovery Tool")
-    print ("Author: Vincent Yiu (@vysecurity)")
-    print ("Contributors: Jan Rude (@whoot); John Bond (@b4ldr)")
-    print ("https://www.github.com/vysec/DomLink")
-    print(("Version: {}".format(__version__)))
-    print ("")
+    print("")
+    print("DomLink Domain Discovery Tool")
+    print("Author: Vincent Yiu (@vysecurity)")
+    print("Contributors: Jan Rude (@whoot); John Bond (@b4ldr)")
+    print("https://www.github.com/vysec/DomLink")
+    print("Version: {}".format(__version__))
+    print("")
 
 def main():
     banner()
@@ -281,4 +281,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.25.0
+requests==2.31.0


### PR DESCRIPTION
This pull request contains the following fixes:

1. Update python-requests to fix security issue
2. use a regex to grep for valid email addresses (mitigates false positives, due to privacy protected whois entries)
3. added a list of "bad strings" used in privacy protected whois entries

**Before:**
```bash
### Company Names:
WORLD COINS USA
BLUEHOST.COM
Whois Privacy Service
Identity Protection Service

### Domain Names:
worldcoin.org

### Email Addresses:
yelliebird@hotmail.com
whois@bluehost.com
please query the rdds service of the registrar of record identified in this output for information o
please query the rdds service of the registrar of record identified in this output for information on how to contact the registrant, admin, or tech contact of the queried domain name.
```

**After:**
```bash
### Company Names:
WORLD COINS USA
BLUEHOST.COM

### Domain Names:
worldcoin.org

### Email Addresses:
yelliebird@hotmail.com
whois@bluehost.com

```
